### PR TITLE
Fix: 메인 페이지 헤더와 사이드바 수정 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "save-my-youth",
       "version": "0.0.0",
       "dependencies": {
         "axios": "^0.27.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,12 @@ const GlobalStyle = createGlobalStyle`
   }
   body {
     font-family: 'Pretendard-Medium', 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
-  } 
+  }
+  button {
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
 `;
 
 const App = () => {

--- a/src/asset/ArrowDown.tsx
+++ b/src/asset/ArrowDown.tsx
@@ -1,0 +1,15 @@
+const ArrowDown = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M6 9L12 15L18 9"
+        stroke="#6C6C6C"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default ArrowDown;

--- a/src/asset/ArrowLeft.tsx
+++ b/src/asset/ArrowLeft.tsx
@@ -1,0 +1,15 @@
+const ArrowLeft = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M9 18L15 12L9 6"
+        stroke="#262626"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default ArrowLeft;

--- a/src/asset/ArrowRight.tsx
+++ b/src/asset/ArrowRight.tsx
@@ -1,9 +1,13 @@
-const ArrowRight = () => {
+export type ArrowRightProps = {
+  color?: string;
+};
+
+const ArrowRight = ({ color = '#929292' }: ArrowRightProps) => {
   return (
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M10 17L15 12L10 7"
-        stroke="#929292"
+        stroke={color}
         stroke-width="2"
         stroke-linecap="square"
         stroke-linejoin="round"

--- a/src/asset/ArrowUp.tsx
+++ b/src/asset/ArrowUp.tsx
@@ -1,0 +1,15 @@
+const ArrowUp = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M18 15L12 9L6 15"
+        stroke="#6C6C6C"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default ArrowUp;

--- a/src/asset/index.ts
+++ b/src/asset/index.ts
@@ -1,4 +1,7 @@
 export { default as ArrowRight } from './ArrowRight';
+export { default as ArrowDown } from './ArrowDown';
+export { default as ArrowLeft } from './ArrowLeft';
+export { default as ArrowUp } from './ArrowUp';
 export { default as Alarm } from './Alarm';
 export { default as Hamburger } from './Hamburger';
 export { default as Search } from './Search';

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import { useCallback, useState } from 'react';
 import { Alarm, Hamburger } from '../../asset';
-// import IconMenu from '../IconMenu';
 import Sidebar from '../Sidebar';
 import COLOR from '../../constants/color';
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -24,7 +24,9 @@ export const StyledButtonContainer = styled.div`
   display: flex;
 `;
 
-export const StyledBurger = styled.div`
+export const StyledAlarm = styled.button``;
+
+export const StyledBurger = styled.button`
   margin-left: 0.5rem;
 `;
 
@@ -48,7 +50,9 @@ const Header = ({ title }: HeaderProps) => {
       <StyledHeader>
         <StyledTitle>{title}</StyledTitle>
         <StyledButtonContainer>
-          <Alarm />
+          <StyledAlarm>
+            <Alarm />
+          </StyledAlarm>
           {/* <IconMenu size={20} /> */}
           <StyledBurger onClick={onClick}>
             <Hamburger />

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,8 +1,16 @@
 import styled from 'styled-components';
 import COLOR from '../../constants/color';
+import { Search } from '../../asset';
+import { Link } from 'react-router-dom';
+import { useRef } from 'react';
+
+export const StyledInputContainer = styled.div`
+  position: relative;
+  width: 90%;
+`;
 
 export const StyledInput = styled.input<{ margin: number }>`
-  width: 90%;
+  width: 100%;
   padding: 1rem 1rem;
   margin: 0 auto;
   border-radius: 8px;
@@ -13,6 +21,12 @@ export const StyledInput = styled.input<{ margin: number }>`
   margin-bottom: 2rem;
   background-repeat: no-repeat;
   background-position: 99%;
+`;
+
+export const StyledSearch = styled.button`
+  position: absolute;
+  top: 20%;
+  right: 16px;
 `;
 
 export type InputPros = {
@@ -32,15 +46,26 @@ const Input = ({
   placeholder = '',
   onChange,
 }: InputPros) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
   return (
-    <StyledInput
-      color={color}
-      disabled={disabled}
-      margin={margin}
-      multiple={multiline}
-      placeholder={placeholder}
-      onChange={onChange}
-    ></StyledInput>
+    <StyledInputContainer>
+      <StyledInput
+        ref={inputRef}
+        color={color}
+        disabled={disabled}
+        margin={margin}
+        multiple={multiline}
+        placeholder={placeholder}
+        onChange={onChange}
+      ></StyledInput>
+
+      <Link to={{ pathname: `/search?${inputRef?.current?.value}` }}>
+        <StyledSearch>
+          <Search />
+        </StyledSearch>
+      </Link>
+    </StyledInputContainer>
   );
 };
 

--- a/src/components/LayoutNavigation/index.tsx
+++ b/src/components/LayoutNavigation/index.tsx
@@ -12,6 +12,7 @@ export const StyledContent = styled.main`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
 `;
 
 export type LayoutNavigationProps = {

--- a/src/components/MainCardItem/index.tsx
+++ b/src/components/MainCardItem/index.tsx
@@ -25,7 +25,7 @@ const MainCardItem = ({ title, 청약리스트 }: MainCardItemProps) => {
       <StyledMainCardItem>
         {청약리스트.map((subscription, i) => (
           <StyledMainCardItemSpan key={subscription.id}>
-            {i + 1}.{subscription.name}
+            {i + 1}. {subscription.name}
           </StyledMainCardItemSpan>
         ))}
       </StyledMainCardItem>

--- a/src/components/Sidebar/OptionItem/index.tsx
+++ b/src/components/Sidebar/OptionItem/index.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const StyledOptionItem = styled.button`
+  width: 100%;
+  height: 1.5rem;
+  padding: 1rem 1.5rem 1rem 1.5rem;
+`;
+
+export type OptionItemProps = {
+  children: React.ReactNode;
+};
+
+const OptionItem = ({ children }: OptionItemProps) => {
+  return <StyledOptionItem>{children}</StyledOptionItem>;
+};
+
+export default OptionItem;

--- a/src/components/Sidebar/OptionItem/index.tsx
+++ b/src/components/Sidebar/OptionItem/index.tsx
@@ -1,17 +1,72 @@
 import styled from 'styled-components';
+import { OptionDecoration } from '..';
+import { ArrowRight, ArrowDown, ArrowUp } from '../../../asset';
+import { COLOR } from '../../../constants';
 
-const StyledOptionItem = styled.button`
+const StyledContainer = styled.div`
   width: 100%;
-  height: 1.5rem;
+  position: relative;
+`;
+
+const StyledButton = styled.button<{
+  underlineHeight: string;
+}>`
+  width: 100%;
+  height: 3.5rem;
+  text-align: left;
   padding: 1rem 1.5rem 1rem 1.5rem;
+  border-bottom: ${(props) => props.underlineHeight} solid ${COLOR.LIGHT_010};
+`;
+
+const StyledSpan = styled.span<{
+  fontSize: string;
+  fontWeight: string;
+}>`
+  font-size: ${(props) => props.fontSize};
+  font-weight: ${(props) => props.fontWeight};
+`;
+
+const StyledArrow = styled.div`
+  position: absolute;
+  top: 20%;
+  right: 16px;
 `;
 
 export type OptionItemProps = {
   children: React.ReactNode;
-};
+} & OptionDecoration;
 
-const OptionItem = ({ children }: OptionItemProps) => {
-  return <StyledOptionItem>{children}</StyledOptionItem>;
+const OptionItem = ({
+  children,
+  fontSize = '1rem',
+  fontWeight = 'regular',
+  underlineHeight = '0',
+  direction = null,
+  disabled = false,
+}: OptionItemProps) => {
+  const getArrowIcon = (direction: string) => {
+    switch (direction) {
+      case 'right':
+        return <ArrowRight />;
+      case 'down':
+        return <ArrowDown />;
+      case 'up':
+        return <ArrowUp />;
+      default:
+        return <></>;
+    }
+  };
+
+  return (
+    <StyledContainer>
+      <StyledButton underlineHeight={underlineHeight} disabled={disabled}>
+        <StyledSpan fontSize={fontSize} fontWeight={fontWeight}>
+          {children}
+        </StyledSpan>
+      </StyledButton>
+      {direction && <StyledArrow>{getArrowIcon(direction)}</StyledArrow>}
+    </StyledContainer>
+  );
 };
 
 export default OptionItem;

--- a/src/components/Sidebar/OptionList/index.tsx
+++ b/src/components/Sidebar/OptionList/index.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import styled from 'styled-components';
+
+const StyledOptionList = styled.aside<{ isOpen: boolean }>`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 80vw;
+  height: 100%;
+  transition: all 1s ease;
+  transform: ${(props) => (props.isOpen ? 'translateX(0)' : 'translateX(100%)')};
+`;
+
+export type OptionListProps = {
+  children: React.ReactNode;
+  onSidebarOpen: (isOpen: boolean) => void;
+  isOpen: boolean;
+};
+
+const OptionList = ({ children, onSidebarOpen, isOpen }: OptionListProps) => {
+  const sidebarRef = useRef(null);
+
+  const onClickOutside = (event: any) => {
+    if (sidebarRef.current && !(sidebarRef.current as any).contains(event.target)) {
+      // TODO: change any type
+      return onSidebarOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('click', onClickOutside, true);
+    return () => {
+      document.removeEventListener('click', onClickOutside, true);
+    };
+  });
+
+  return (
+    <StyledOptionList ref={sidebarRef} isOpen={isOpen}>
+      {children}
+    </StyledOptionList>
+  );
+};
+
+export default OptionList;

--- a/src/components/Sidebar/OptionList/index.tsx
+++ b/src/components/Sidebar/OptionList/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
+import { COLOR } from '../../../constants';
 
 const StyledOptionList = styled.aside<{ isOpen: boolean }>`
   position: absolute;
@@ -8,7 +9,9 @@ const StyledOptionList = styled.aside<{ isOpen: boolean }>`
   width: 80vw;
   height: 100%;
   transition: all 1s ease;
+  z-index: 1;
   transform: ${(props) => (props.isOpen ? 'translateX(0)' : 'translateX(100%)')};
+  background-color: ${COLOR.WHITE};
 `;
 
 export type OptionListProps = {
@@ -20,6 +23,7 @@ export type OptionListProps = {
 const OptionList = ({ children, onSidebarOpen, isOpen }: OptionListProps) => {
   const sidebarRef = useRef(null);
 
+  // ref: https://codesandbox.io/s/outside-click-hook-uc8bo?file=/src/outsideClick.js
   const onClickOutside = (event: any) => {
     if (sidebarRef.current && !(sidebarRef.current as any).contains(event.target)) {
       // TODO: change any type

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,8 +1,10 @@
+import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import OptionItem from './OptionItem';
 import OptionList from './OptionList';
+import { useState } from 'react';
 
-export type ArrowDirection = 'right' | 'down' | 'left' | 'up';
+export type ArrowDirection = 'right' | 'down' | 'up';
 
 export type OptionDecoration = {
   fontSize?: string;
@@ -23,7 +25,7 @@ export type SidebarProps = {
 };
 
 const Sidebar = ({ onSidebarOpen, isOpen }: SidebarProps) => {
-  const optionList: Array<Option> = [
+  const userSetting: Array<Option> = [
     {
       name: '제이미 님',
       link: '/',
@@ -52,28 +54,51 @@ const Sidebar = ({ onSidebarOpen, isOpen }: SidebarProps) => {
       fontWeight: 'bold',
       underlineHeight: '2px',
     },
-    {
-      name: '고객센터',
-      link: '/',
-      fontSize: '1rem',
-      fontWeight: 'bold',
-      underlineHeight: '2px',
-      direction: 'down',
-    },
-    {
-      name: '공지사항',
-      link: '/',
-      fontSize: '0.875rem',
-      underlineHeight: '2px',
-      direction: 'right',
-    },
-    {
-      name: '서비스해지',
-      link: '/',
-      fontSize: '0.875rem',
-      underlineHeight: '8px',
-      direction: 'right',
-    },
+  ];
+
+  const help: Record<string, Array<Option>> = {
+    title: [
+      {
+        name: '고객센터',
+        link: '/',
+        fontSize: '1rem',
+        fontWeight: 'bold',
+        underlineHeight: '2px',
+      },
+    ],
+    option: [
+      {
+        name: '공지사항',
+        link: '/',
+        fontSize: '0.875rem',
+        underlineHeight: '2px',
+        direction: 'right',
+      },
+      {
+        name: 'FAQ',
+        link: '/',
+        fontSize: '0.875rem',
+        underlineHeight: '2px',
+        direction: 'right',
+      },
+      {
+        name: '1:1 문의',
+        link: '/',
+        fontSize: '0.875rem',
+        underlineHeight: '2px',
+        direction: 'right',
+      },
+      {
+        name: '서비스해지',
+        link: '/',
+        fontSize: '0.875rem',
+        underlineHeight: '8px',
+        direction: 'right',
+      },
+    ],
+  };
+
+  const connection: Array<Option> = [
     {
       name: '로그아웃',
       link: '/',
@@ -87,9 +112,68 @@ const Sidebar = ({ onSidebarOpen, isOpen }: SidebarProps) => {
     },
   ];
 
+  const [helpClicked, setHelpClicked] = useState(false);
+
+  const toggleHelp = () => {
+    return setHelpClicked(!helpClicked);
+  };
+
   return (
     <OptionList onSidebarOpen={onSidebarOpen} isOpen={isOpen}>
-      {optionList.map((option) => (
+      {userSetting.map((option) => (
+        <Link key={`${option.name}-${option.link}`} to={option.link}>
+          <OptionItem
+            fontSize={option.fontSize}
+            fontWeight={option.fontWeight}
+            underlineHeight={option.underlineHeight}
+            direction={option.direction}
+            disabled={option.disabled}
+          >
+            {option.name}
+          </OptionItem>
+        </Link>
+      ))}
+
+      <div id="accordion">
+        <div id="고객센터" onClick={toggleHelp}>
+          {help.title.map((option) => {
+            const dynamicDirection = helpClicked ? 'up' : 'down';
+
+            return (
+              <Link key={`${option.name}-${option.link}`} to={option.link}>
+                <OptionItem
+                  fontSize={option.fontSize}
+                  fontWeight={option.fontWeight}
+                  underlineHeight={option.underlineHeight}
+                  direction={dynamicDirection}
+                  disabled={option.disabled}
+                >
+                  {option.name}
+                </OptionItem>
+              </Link>
+            );
+          })}
+        </div>
+        {helpClicked && (
+          <div id="옵션">
+            {help.option.map((option) => (
+              <Link key={`${option.name}-${option.link}`} to={option.link}>
+                <OptionItem
+                  fontSize={option.fontSize}
+                  fontWeight={option.fontWeight}
+                  underlineHeight={option.underlineHeight}
+                  direction={option.direction}
+                  disabled={option.disabled}
+                >
+                  {option.name}
+                </OptionItem>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {connection.map((option) => (
         <Link key={`${option.name}-${option.link}`} to={option.link}>
           <OptionItem
             fontSize={option.fontSize}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,12 +1,21 @@
 import { Link } from 'react-router-dom';
-import styled from 'styled-components';
 import OptionItem from './OptionItem';
 import OptionList from './OptionList';
+
+export type ArrowDirection = 'right' | 'down' | 'left' | 'up';
+
+export type OptionDecoration = {
+  fontSize?: string;
+  fontWeight?: string;
+  underlineHeight?: string;
+  direction?: ArrowDirection | null;
+  disabled?: boolean;
+};
 
 type Option = {
   name: string;
   link: string;
-};
+} & OptionDecoration;
 
 export type SidebarProps = {
   onSidebarOpen: (isOpen: boolean) => void;
@@ -16,16 +25,65 @@ export type SidebarProps = {
 const Sidebar = ({ onSidebarOpen, isOpen }: SidebarProps) => {
   const optionList: Array<Option> = [
     {
-      name: '헬렌',
+      name: '제이미 님',
       link: '/',
+      fontSize: '1rem',
+      fontWeight: 'bold',
+      direction: 'right',
     },
     {
-      name: '알림 설정',
+      name: '늘 행운을 빌어요! :)',
       link: '/',
+      fontSize: '0.875rem',
+      underlineHeight: '4px',
+      disabled: true,
     },
     {
       name: '좋아요',
       link: '/',
+      fontSize: '1rem',
+      fontWeight: 'bold',
+      underlineHeight: '2px',
+    },
+    {
+      name: '알림 설정',
+      link: '/',
+      fontSize: '1rem',
+      fontWeight: 'bold',
+      underlineHeight: '2px',
+    },
+    {
+      name: '고객센터',
+      link: '/',
+      fontSize: '1rem',
+      fontWeight: 'bold',
+      underlineHeight: '2px',
+      direction: 'down',
+    },
+    {
+      name: '공지사항',
+      link: '/',
+      fontSize: '0.875rem',
+      underlineHeight: '2px',
+      direction: 'right',
+    },
+    {
+      name: '서비스해지',
+      link: '/',
+      fontSize: '0.875rem',
+      underlineHeight: '8px',
+      direction: 'right',
+    },
+    {
+      name: '로그아웃',
+      link: '/',
+      fontSize: '1rem',
+      underlineHeight: '2px',
+    },
+    {
+      name: '연동해제',
+      link: '/',
+      fontSize: '1rem',
     },
   ];
 
@@ -33,7 +91,15 @@ const Sidebar = ({ onSidebarOpen, isOpen }: SidebarProps) => {
     <OptionList onSidebarOpen={onSidebarOpen} isOpen={isOpen}>
       {optionList.map((option) => (
         <Link key={`${option.name}-${option.link}`} to={option.link}>
-          <OptionItem>{option.name}</OptionItem>
+          <OptionItem
+            fontSize={option.fontSize}
+            fontWeight={option.fontWeight}
+            underlineHeight={option.underlineHeight}
+            direction={option.direction}
+            disabled={option.disabled}
+          >
+            {option.name}
+          </OptionItem>
         </Link>
       ))}
     </OptionList>

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,22 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-
-const StyledOptionList = styled.aside<{ isOpen: boolean }>`
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 80%;
-  height: 100%;
-  transition: all 1s ease;
-  transform: ${(props) => (props.isOpen ? 'translateX(0)' : 'translateX(100%)')};
-`;
-
-const StyledOptionItem = styled.button`
-  width: 100%;
-  height: 1.5rem;
-  padding: 10px;
-`;
+import OptionItem from './OptionItem';
+import OptionList from './OptionList';
 
 type Option = {
   name: string;
@@ -24,13 +9,11 @@ type Option = {
 };
 
 export type SidebarProps = {
-  isOpen: boolean;
   onSidebarOpen: (isOpen: boolean) => void;
+  isOpen: boolean;
 };
 
 const Sidebar = ({ onSidebarOpen, isOpen }: SidebarProps) => {
-  const sidebarRef = useRef(null);
-
   const optionList: Array<Option> = [
     {
       name: '헬렌',
@@ -46,28 +29,14 @@ const Sidebar = ({ onSidebarOpen, isOpen }: SidebarProps) => {
     },
   ];
 
-  const onClickOutside = (event: any) => {
-    if (sidebarRef.current && !(sidebarRef.current as any).contains(event.target)) {
-      // TODO: change any type
-      return onSidebarOpen(false);
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener('click', onClickOutside, true);
-    return () => {
-      document.removeEventListener('click', onClickOutside, true);
-    };
-  });
-
   return (
-    <StyledOptionList ref={sidebarRef} isOpen={isOpen}>
+    <OptionList onSidebarOpen={onSidebarOpen} isOpen={isOpen}>
       {optionList.map((option) => (
         <Link key={`${option.name}-${option.link}`} to={option.link}>
-          <StyledOptionItem>{option.name}</StyledOptionItem>
+          <OptionItem>{option.name}</OptionItem>
         </Link>
       ))}
-    </StyledOptionList>
+    </OptionList>
   );
 };
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

feat/40/create-component -> dev

### 변경 사항

- 헤더에 있는 알람과 햄버거에 버튼 적용 (div->button)
- 헤더에 검색 버튼 추가
- 헤더 검색 버튼 누르면 search로 이동
- 사이드바 구현

### 앞으로 수정해야 할 사항

- 사이드바가 숨어있을 때도 화면에서 보임
- 사이드바의 height가 사이트의 100%를 차지하지 않음
- 사이드바에서 옵션 보여주는 부분 리팩토링

### 테스트 결과

![화면 기록 2022-05-16 오후 4 01 16](https://user-images.githubusercontent.com/64337152/168537678-f7fadf37-1d44-48a2-a979-12d827217d8f.gif)

### Issue

resolved: #40