### PR TITLE
Fix: same key in footer

### DIFF
--- a/frontend/src/components/Footer/index.tsx
+++ b/frontend/src/components/Footer/index.tsx
@@ -50,7 +50,7 @@ const Footer = () => {
     <StyledContainer>
       <StyledFlex>
         {ptag.map((i) => (
-          <StyledTag key={i.toString()} onClick={() => navigate(`/${i.nav}`)}>
+          <StyledTag key={i.title} onClick={() => navigate(`/${i.nav}`)}>
             {i.title}
           </StyledTag>
         ))}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/237/same-key -> dev

### 변경 사항

```
    <StyledContainer>
      <StyledFlex>
        {ptag.map((i) => (
          <StyledTag key={i.title} onClick={() => navigate(`/${i.nav}`)}> -----> toString. -> title
            {i.title}
          </StyledTag>
        ))}
```

### Issue

resolved: #237 

