### PR TITLE
Refactor: Card 컴포넌트 2개로 분리

### DIFF
--- a/frontend/src/components/ApplyCard.tsx
+++ b/frontend/src/components/ApplyCard.tsx
@@ -9,13 +9,7 @@ import House4 from '../assets/images/house/image4.png';
 import House5 from '../assets/images/house/image5.png';
 import House6 from '../assets/images/house/image6.png';
 import PALETTE from '../constants/palette';
-import {
-  CARD_BORDER_RADIUS,
-  CARD_HEIGHT_COLUMN,
-  CARD_HEIGHT_ROW,
-  CARD_WIDTH_COLUMN,
-  CARD_WIDTH_ROW,
-} from '../constants/variables';
+import { CARD_BORDER_RADIUS } from '../constants/variables';
 
 export type CardProps = {
   subscriptionId: number;
@@ -72,8 +66,8 @@ const ApplyCard = ({
 export default ApplyCard;
 
 const StyledCard = styled.article`
-  width: ${CARD_WIDTH_COLUMN}px;
-  height: ${CARD_HEIGHT_COLUMN}px;
+  width: 16.25rem;
+  height: 12.125rem;
   border-radius: ${CARD_BORDER_RADIUS}px;
   display: flex;
   flex-direction: column;
@@ -81,42 +75,35 @@ const StyledCard = styled.article`
 `;
 
 const StyledImage = styled.img<{ image: string }>`
-  width: initial;
-  height: 124px;
+  height: 7.75rem;
   border-radius: ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px 0 0;
   content: url(${(props) => props.image});
   object-fit: cover;
 `;
 
 const StyledTextContainer = styled.div`
-  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  background-color: ${PALETTE.LIGHT_010};
+  background: ${PALETTE.LIGHT_010};
   border-radius: 0 0 ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px;
 `;
 
 const StyledTitle = styled.span`
-  width: 100%;
-  height: 40px;
-  font-size: 1rem;
   font-weight: bold;
   line-height: 1.5rem;
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   background: ${PALETTE.LIGHT_010};
 `;
 
 const StyledLikeNumContainer = styled.div`
-  width: 100%;
-  height: 30px;
   display: flex;
   justify-content: flex-end;
   align-items: center;
   background: ${PALETTE.LIGHT_010};
   border-radius: 0 0 ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px;
-  padding: 6px 8px;
-  gap: 4px;
+  padding: 0.375rem 0.5rem;
+  gap: 0.25rem;
 `;
 
 const StyledLikeNum = styled.span`

--- a/frontend/src/components/ApplyCard.tsx
+++ b/frontend/src/components/ApplyCard.tsx
@@ -16,18 +16,15 @@ import {
   CARD_WIDTH_COLUMN,
   CARD_WIDTH_ROW,
 } from '../constants/variables';
-import { CardDirection } from '../types';
 
 export type CardProps = {
-  direction?: CardDirection;
   subscriptionId: number;
   image?: string;
   title: string;
   likeNum: number;
 };
 
-const Card = ({
-  direction = 'column',
+const ApplyCard = ({
   subscriptionId,
   image = `House` + String(Math.floor(Math.random() * 6 + 1)),
   title,
@@ -54,15 +51,14 @@ const Card = ({
 
   return (
     <StyledCard
-      direction={direction}
       onClick={() =>
         navigate('/detail', {
           state: { id: subscriptionId, imgLink: getImage(image) },
         })
       }
     >
-      <StyledImage direction={direction} image={getImage(image)} />
-      <StyledTextContainer direction={direction}>
+      <StyledImage image={getImage(image)} />
+      <StyledTextContainer>
         <StyledTitle>{title}</StyledTitle>
         <StyledLikeNumContainer>
           <BlueHeart />
@@ -73,39 +69,32 @@ const Card = ({
   );
 };
 
-export default Card;
+export default ApplyCard;
 
-const StyledCard = styled.article<{ direction?: CardDirection }>`
-  width: ${(props) => (props.direction === 'column' ? `${CARD_WIDTH_COLUMN}px` : '100%')};
-  height: ${(props) => (props.direction === 'column' ? `${CARD_HEIGHT_COLUMN}px` : '100%')};
+const StyledCard = styled.article`
+  width: ${CARD_WIDTH_COLUMN}px;
+  height: ${CARD_HEIGHT_COLUMN}px;
   border-radius: ${CARD_BORDER_RADIUS}px;
   display: flex;
-  flex-direction: ${(props) => (props.direction === 'column' ? 'column' : 'row')};
+  flex-direction: column;
   cursor: pointer;
 `;
 
-const StyledImage = styled.img<{ direction?: CardDirection; image: string }>`
-  width: ${(props) => (props.direction === 'column' ? 'initial' : `${CARD_WIDTH_ROW}px`)};
-  height: ${(props) => (props.direction === 'column' ? ' 124px' : `${CARD_HEIGHT_ROW}px`)};
-  border-radius: ${(props) =>
-    props.direction === 'column'
-      ? `${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px 0 0`
-      : `${CARD_BORDER_RADIUS}px 0  0 ${CARD_BORDER_RADIUS}px`};
-
+const StyledImage = styled.img<{ image: string }>`
+  width: initial;
+  height: 124px;
+  border-radius: ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px 0 0;
   content: url(${(props) => props.image});
   object-fit: cover;
 `;
 
-const StyledTextContainer = styled.div<{ direction?: CardDirection }>`
+const StyledTextContainer = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
   background-color: ${PALETTE.LIGHT_010};
-  border-radius: ${(props) =>
-    props.direction === 'column'
-      ? `0 0 ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px`
-      : `0 ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px 0`};
+  border-radius: 0 0 ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px;
 `;
 
 const StyledTitle = styled.span`

--- a/frontend/src/components/ApplyCard.tsx
+++ b/frontend/src/components/ApplyCard.tsx
@@ -3,11 +3,6 @@ import styled from 'styled-components';
 
 import { ReactComponent as BlueHeart } from '../assets/icons/blueHeart.svg';
 import House1 from '../assets/images/house/image1.png';
-import House2 from '../assets/images/house/image2.png';
-import House3 from '../assets/images/house/image3.png';
-import House4 from '../assets/images/house/image4.png';
-import House5 from '../assets/images/house/image5.png';
-import House6 from '../assets/images/house/image6.png';
 import PALETTE from '../constants/palette';
 import { CARD_BORDER_RADIUS } from '../constants/variables';
 
@@ -18,40 +13,18 @@ export type CardProps = {
   likeNum: number;
 };
 
-const ApplyCard = ({
-  subscriptionId,
-  image = `House` + String(Math.floor(Math.random() * 6 + 1)),
-  title,
-  likeNum,
-}: CardProps) => {
+const ApplyCard = ({ subscriptionId, image = House1, title, likeNum }: CardProps) => {
   const navigate = useNavigate();
-
-  const getImage = (image: string) => {
-    switch (image) {
-      case 'House1':
-        return House1;
-      case 'House2':
-        return House2;
-      case 'House3':
-        return House3;
-      case 'House4':
-        return House4;
-      case 'House5':
-        return House5;
-      case 'House6':
-        return House6;
-    }
-  };
 
   return (
     <StyledCard
       onClick={() =>
         navigate('/detail', {
-          state: { id: subscriptionId, imgLink: getImage(image) },
+          state: { id: subscriptionId, imgLink: House1 },
         })
       }
     >
-      <StyledImage image={getImage(image)} />
+      <StyledImage image={image} />
       <StyledTextContainer>
         <StyledTitle>{title}</StyledTitle>
         <StyledLikeNumContainer>

--- a/frontend/src/components/ApplyListItem.tsx
+++ b/frontend/src/components/ApplyListItem.tsx
@@ -3,11 +3,6 @@ import styled from 'styled-components';
 
 import { ReactComponent as BlueHeart } from '../assets/icons/blueHeart.svg';
 import House1 from '../assets/images/house/image1.png';
-import House2 from '../assets/images/house/image2.png';
-import House3 from '../assets/images/house/image3.png';
-import House4 from '../assets/images/house/image4.png';
-import House5 from '../assets/images/house/image5.png';
-import House6 from '../assets/images/house/image6.png';
 import PALETTE from '../constants/palette';
 import { CARD_BORDER_RADIUS } from '../constants/variables';
 
@@ -18,40 +13,18 @@ export type ApplyListItemProps = {
   likeNum: number;
 };
 
-const ApplyListItem = ({
-  subscriptionId,
-  image = `House` + String(Math.floor(Math.random() * 6 + 1)),
-  title,
-  likeNum,
-}: ApplyListItemProps) => {
+const ApplyListItem = ({ subscriptionId, image = House1, title, likeNum }: ApplyListItemProps) => {
   const navigate = useNavigate();
-
-  const getImage = (image: string) => {
-    switch (image) {
-      case 'House1':
-        return House1;
-      case 'House2':
-        return House2;
-      case 'House3':
-        return House3;
-      case 'House4':
-        return House4;
-      case 'House5':
-        return House5;
-      case 'House6':
-        return House6;
-    }
-  };
 
   return (
     <StyledCard
       onClick={() =>
         navigate('/detail', {
-          state: { id: subscriptionId, imgLink: getImage(image) },
+          state: { id: subscriptionId, imgLink: image },
         })
       }
     >
-      <StyledImage image={getImage(image)} />
+      <StyledImage image={image} />
       <StyledTextContainer>
         <StyledTitle>{title}</StyledTitle>
         <StyledLikeNumContainer>

--- a/frontend/src/components/ApplyListItem.tsx
+++ b/frontend/src/components/ApplyListItem.tsx
@@ -1,0 +1,125 @@
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { ReactComponent as BlueHeart } from '../assets/icons/blueHeart.svg';
+import House1 from '../assets/images/house/image1.png';
+import House2 from '../assets/images/house/image2.png';
+import House3 from '../assets/images/house/image3.png';
+import House4 from '../assets/images/house/image4.png';
+import House5 from '../assets/images/house/image5.png';
+import House6 from '../assets/images/house/image6.png';
+import PALETTE from '../constants/palette';
+import {
+  CARD_BORDER_RADIUS,
+  CARD_HEIGHT_COLUMN,
+  CARD_HEIGHT_ROW,
+  CARD_WIDTH_COLUMN,
+  CARD_WIDTH_ROW,
+} from '../constants/variables';
+
+export type ApplyListItemProps = {
+  subscriptionId: number;
+  image?: string;
+  title: string;
+  likeNum: number;
+};
+
+const ApplyListItem = ({
+  subscriptionId,
+  image = `House` + String(Math.floor(Math.random() * 6 + 1)),
+  title,
+  likeNum,
+}: ApplyListItemProps) => {
+  const navigate = useNavigate();
+
+  const getImage = (image: string) => {
+    switch (image) {
+      case 'House1':
+        return House1;
+      case 'House2':
+        return House2;
+      case 'House3':
+        return House3;
+      case 'House4':
+        return House4;
+      case 'House5':
+        return House5;
+      case 'House6':
+        return House6;
+    }
+  };
+
+  return (
+    <StyledCard
+      onClick={() =>
+        navigate('/detail', {
+          state: { id: subscriptionId, imgLink: getImage(image) },
+        })
+      }
+    >
+      <StyledImage image={getImage(image)} />
+      <StyledTextContainer>
+        <StyledTitle>{title}</StyledTitle>
+        <StyledLikeNumContainer>
+          <BlueHeart />
+          <StyledLikeNum>{likeNum}</StyledLikeNum>
+        </StyledLikeNumContainer>
+      </StyledTextContainer>
+    </StyledCard>
+  );
+};
+
+export default ApplyListItem;
+
+const StyledCard = styled.article`
+  width: 100%;
+  height: 100%;
+  border-radius: ${CARD_BORDER_RADIUS}px;
+  display: flex;
+  flex-direction: row;
+  cursor: pointer;
+`;
+
+const StyledImage = styled.img<{ image: string }>`
+  width: ${CARD_WIDTH_ROW}px;
+  height: ${CARD_HEIGHT_ROW}px;
+  border-radius: ${CARD_BORDER_RADIUS}px 0 0 ${CARD_BORDER_RADIUS}px;
+  content: url(${(props) => props.image});
+  object-fit: cover;
+`;
+
+const StyledTextContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  background-color: ${PALETTE.LIGHT_010};
+  border-radius: 0 ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px 0;
+`;
+
+const StyledTitle = styled.span`
+  width: 100%;
+  height: 40px;
+  font-size: 1rem;
+  font-weight: bold;
+  line-height: 1.5rem;
+  padding: 8px 12px;
+  background: ${PALETTE.LIGHT_010};
+`;
+
+const StyledLikeNumContainer = styled.div`
+  width: 100%;
+  height: 30px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  background: ${PALETTE.LIGHT_010};
+  border-radius: 0 0 ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px;
+  padding: 6px 8px;
+  gap: 4px;
+`;
+
+const StyledLikeNum = styled.span`
+  font-size: 0.75rem;
+  color: ${PALETTE.DARK_020};
+`;

--- a/frontend/src/components/ApplyListItem.tsx
+++ b/frontend/src/components/ApplyListItem.tsx
@@ -9,13 +9,7 @@ import House4 from '../assets/images/house/image4.png';
 import House5 from '../assets/images/house/image5.png';
 import House6 from '../assets/images/house/image6.png';
 import PALETTE from '../constants/palette';
-import {
-  CARD_BORDER_RADIUS,
-  CARD_HEIGHT_COLUMN,
-  CARD_HEIGHT_ROW,
-  CARD_WIDTH_COLUMN,
-  CARD_WIDTH_ROW,
-} from '../constants/variables';
+import { CARD_BORDER_RADIUS } from '../constants/variables';
 
 export type ApplyListItemProps = {
   subscriptionId: number;
@@ -73,7 +67,6 @@ export default ApplyListItem;
 
 const StyledCard = styled.article`
   width: 100%;
-  height: 100%;
   border-radius: ${CARD_BORDER_RADIUS}px;
   display: flex;
   flex-direction: row;
@@ -81,8 +74,8 @@ const StyledCard = styled.article`
 `;
 
 const StyledImage = styled.img<{ image: string }>`
-  width: ${CARD_WIDTH_ROW}px;
-  height: ${CARD_HEIGHT_ROW}px;
+  width: 5.875rem;
+  height: 6.375rem;
   border-radius: ${CARD_BORDER_RADIUS}px 0 0 ${CARD_BORDER_RADIUS}px;
   content: url(${(props) => props.image});
   object-fit: cover;
@@ -99,24 +92,19 @@ const StyledTextContainer = styled.div`
 
 const StyledTitle = styled.span`
   width: 100%;
-  height: 40px;
-  font-size: 1rem;
   font-weight: bold;
-  line-height: 1.5rem;
-  padding: 8px 12px;
+  padding: 0.5rem 0.75rem;
   background: ${PALETTE.LIGHT_010};
 `;
 
 const StyledLikeNumContainer = styled.div`
-  width: 100%;
-  height: 30px;
   display: flex;
   justify-content: flex-end;
   align-items: center;
   background: ${PALETTE.LIGHT_010};
   border-radius: 0 0 ${CARD_BORDER_RADIUS}px ${CARD_BORDER_RADIUS}px;
-  padding: 6px 8px;
-  gap: 4px;
+  padding: 0.375rem 0.5rem;
+  gap: 0.25rem;
 `;
 
 const StyledLikeNum = styled.span`

--- a/frontend/src/components/CardSlider.tsx
+++ b/frontend/src/components/CardSlider.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { SubscriptionUsedFront } from '../types';
-import Card from './Card';
+import ApplyCard from './ApplyCard';
 import TodaySubscriptionNull from './TodaySubscriptionNull';
 
 export type CardSliderProps = {
@@ -16,7 +16,7 @@ const CardSlider = ({ subscriptions }: CardSliderProps) => {
         nullShow={subscriptions.length < 2}
       >
         {subscriptions.map((subscription) => (
-          <Card
+          <ApplyCard
             subscriptionId={subscription.id}
             key={subscription.id}
             title={subscription.houseName}

--- a/frontend/src/components/TodaySubscriptionNull.tsx
+++ b/frontend/src/components/TodaySubscriptionNull.tsx
@@ -2,7 +2,6 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import PALETTE from '../constants/palette';
-import { CARD_HEIGHT_COLUMN, CARD_WIDTH_COLUMN } from '../constants/variables';
 
 const TodaySubscriptionNull = () => {
   return (
@@ -25,8 +24,8 @@ export const StyledCard = styled.article`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: ${CARD_WIDTH_COLUMN}px;
-  height: ${CARD_HEIGHT_COLUMN}px;
+  width: 16.25rem;
+  height: 12.125rem;
   background: rgba(171, 210, 254, 0.2);
   border-radius: 8px;
 `;

--- a/frontend/src/constants/variables.ts
+++ b/frontend/src/constants/variables.ts
@@ -1,5 +1,1 @@
-export const CARD_WIDTH_COLUMN = 260;
-export const CARD_WIDTH_ROW = 94;
-export const CARD_HEIGHT_COLUMN = 194;
-export const CARD_HEIGHT_ROW = 102;
 export const CARD_BORDER_RADIUS = 8;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import MainBanner from '../assets/images/mainBanner.svg';
 import { CardSlider, Input, LayoutNavigation } from '../components';
-import Card from '../components/Card';
+import ApplyListItem from '../components/ApplyListItem';
 import Description from '../components/Description';
 import Indexing from '../components/Indexing';
 import ListTitle from '../components/ListTitle';
@@ -58,8 +58,7 @@ const Home = () => {
           <StyledFlex>
             {popularityList.slice(0, 3).map((item, index) => (
               <Indexing key={item.id} index={index + 1}>
-                <Card
-                  direction="row"
+                <ApplyListItem
                   subscriptionId={item.id}
                   title={item.houseName}
                   likeNum={item.likeNum || 0}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -107,5 +107,4 @@ export type IDetailOptions = {
 };
 
 export type ListType = 'popular' | 'new';
-export type CardDirection = 'column' | 'row';
 export type IconName = 'hamburger' | 'headerTitle' | 'arrowLeft';


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/split-card -> dev

### 변경 사항

- `Card`의 재사용성이 떨어진다는 판단 하에 `ApplyCard`와 `ApplyListItem`으로 분리하였습니다. 

### 테스트 결과

<img width="420" alt="image" src="https://user-images.githubusercontent.com/64337152/197139238-165a0d94-38a6-4f11-9512-019b24e4af51.png">

### Issue

- 연결 안 함

