### PR TITLE
Fix: 메인 페이지에서 컴포넌트가 서로 겹쳐보이는 현상 해결

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -164,7 +164,6 @@ export const StyledFlex = styled.div`
 
 export const StyledSectionContainer = styled.section<{ alignItems: string }>`
   width: 100%;
-  height: 286px;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
style/home -> dev

### 테스트 결과

기존에 있던 스타일링은 로딩하고 있을 때 `section`의 영역을 잡아놓기 위해 두었던 거라, 스켈레톤을 추가하여 해결할 예정입니다.

<img width="447" alt="image" src="https://user-images.githubusercontent.com/64337152/197141584-35faecef-1cb1-4766-8bc9-7c13cc043278.png">

