### PR TITLE
Fix: 청약 리스트 요청 API 변경

### DIFF
--- a/frontend/src/components/SearchSortButton.tsx
+++ b/frontend/src/components/SearchSortButton.tsx
@@ -1,9 +1,5 @@
 import styled from 'styled-components';
-import React,{useState} from 'react';
 import PALETTE from '../constants/palette';
-import { SubscriptionUsedFront } from '../types'
-import useSubscription from '../hooks/useSubscription';
-
 
 interface props {
   isTarget: boolean;
@@ -12,17 +8,15 @@ export type MessageProps = {
   totalMessage: string;
 };
 
-
-const SearchSortButton = ({ totalMessage,subData }:any) => {
-
+const SearchSortButton = ({ totalMessage, subData }: any) => {
   return (
     <div>
       <StyledWrapper>
-        <StyledButton isTarget={true} >인기순</StyledButton>
+        <StyledButton isTarget={true}>인기순</StyledButton>
         <StyledButton isTarget={true}>최신순</StyledButton>
       </StyledWrapper>
     </div>
-  )
+  );
 };
 
 const StyledButton = styled.button<{ isTarget: boolean }>`
@@ -32,18 +26,17 @@ const StyledButton = styled.button<{ isTarget: boolean }>`
   line-height: 1.5;
   color: ${PALETTE.BLACK};
   background-color: ${PALETTE.LIGHT_010};
-  margin-right:10px;
+  margin-right: 10px;
   .btn.active {
-  background-color:${(props) => (props.isTarget ? 'PALETTE.LIGHT_010' : 'PALETTE.PRI_MAIN')};       
-  color: ${(props) => (props.isTarget ? 'PALETTE.BLACK' : 'PALETTE.LIGHT_010')};
-}
+    background-color: ${(props) => (props.isTarget ? 'PALETTE.LIGHT_010' : 'PALETTE.PRI_MAIN')};
+    color: ${(props) => (props.isTarget ? 'PALETTE.BLACK' : 'PALETTE.LIGHT_010')};
+  }
 `;
 
-
 const StyledWrapper = styled.div`
-  padding-rignt:10px;
-  padding-left:20px;
-  display:flex;
-`
+  padding-right: 10px;
+  padding-left: 20px;
+  display: flex;
+`;
 
 export default SearchSortButton;

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+    readonly VITE_APP_API_KEY: string
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv
+}

--- a/frontend/src/hooks/useApply.tsx
+++ b/frontend/src/hooks/useApply.tsx
@@ -3,13 +3,14 @@ import { useEffect, useState } from 'react';
 
 import tmpImg from '../assets/images/picture2.png';
 import { ListType, SubscriptionResponse, SubscriptionUsedFront } from '../types';
+const { VITE_APP_API_KEY } = import.meta.env;
 
-const SERVER_SUBSCRIPTION_URL = `https://secret-reaches-74853.herokuapp.com/api/subscription/perPage=10`;
-const SERVER_LIKE_COUNT_URL = `https://secret-reaches-74853.herokuapp.com/api/like`;
+const SERVER_SUBSCRIPTION_URL = `https://api.odcloud.kr/api/ApplyhomeInfoDetailSvc/v1/getAPTLttotPblancDetail&serviceKey=${VITE_APP_API_KEY}`;
+const SERVER_LIKE_COUNT_URL = 'https://secret-reaches-74853.herokuapp.com/api/like';
 
 export type Request = ListType | 'today' | 'theOtherDay' | 'region' | 'id';
 
-const useTodaySubscription = (request: Request, region?: string, id?: number) => {
+const useTodayApply = (request: Request, region?: string, id?: number) => {
   const [loading, setLoading] = useState(false);
   const [subscriptions, setSubscriptions] = useState<SubscriptionUsedFront[]>([]);
 
@@ -127,4 +128,4 @@ const useTodaySubscription = (request: Request, region?: string, id?: number) =>
   return { loading, subscriptions };
 };
 
-export default useTodaySubscription;
+export default useTodayApply;

--- a/frontend/src/hooks/useApply.tsx
+++ b/frontend/src/hooks/useApply.tsx
@@ -5,61 +5,62 @@ import tmpImg from '../assets/images/picture2.png';
 import { ListType, SubscriptionResponse, SubscriptionUsedFront } from '../types';
 const { VITE_APP_API_KEY } = import.meta.env;
 
-const SERVER_SUBSCRIPTION_URL = `https://api.odcloud.kr/api/ApplyhomeInfoDetailSvc/v1/getAPTLttotPblancDetail&serviceKey=${VITE_APP_API_KEY}`;
+const SERVER_SUBSCRIPTION_URL = `https://api.odcloud.kr/api/ApplyhomeInfoDetailSvc/v1/getAPTLttotPblancDetail?page=1&perPage=10&serviceKey=${VITE_APP_API_KEY}`;
 const SERVER_LIKE_COUNT_URL = 'https://secret-reaches-74853.herokuapp.com/api/like';
 
-export type Request = ListType | 'today' | 'theOtherDay' | 'region' | 'id';
+export type Condition = ListType | 'today' | 'theOtherDay' | 'region' | 'id';
 
-const useTodayApply = (request: Request, region?: string, id?: number) => {
+const useApply = (options: { condition: Condition; region?: string; id?: number }) => {
   const [loading, setLoading] = useState(false);
-  const [subscriptions, setSubscriptions] = useState<SubscriptionUsedFront[]>([]);
+  const [applies, setApplies] = useState<SubscriptionUsedFront[]>([]);
 
   const now = new Date();
   const today = now.toJSON().slice(0, 10).replace(/-/g, '-');
   const theOtherDay = new Date(now.setDate(now.getDate() - 7)).toJSON().slice(0, 10);
 
-  const getRequestUrl = (request: Request, region?: string, id?: number): string => {
+  const getRequestUrlByOptions = (): string => {
     let condition = '';
-    switch (request) {
-      case 'today': {
-        condition = `&cond[RCRIT_PBLANC_DE::GTE]=${today}`;
-        break;
-      }
+
+    switch (options.condition) {
       case 'theOtherDay':
       case 'popular':
       case 'new': {
         condition = `&cond[RCRIT_PBLANC_DE::GTE]=${theOtherDay}`;
         break;
       }
+      case 'today': {
+        condition = `&cond[RCRIT_PBLANC_DE::GTE]=${today}`;
+        break;
+      }
       case 'region': {
-        condition = `&cond[SUBSCRPT_AREA_CODE_NM::EQ]=${region}`;
+        condition = `&cond[SUBSCRPT_AREA_CODE_NM::EQ]=${options.region}`;
         break;
       }
       case 'id': {
-        condition = `&cond[PBLANC_NO::EQ]=${id}`;
+        condition = `&cond[PBLANC_NO::EQ]=${options.id}`;
         break;
       }
     }
     return SERVER_SUBSCRIPTION_URL + condition;
   };
 
-  const getSubscriptionsFromServer = async () => {
+  const get = async () => {
     try {
       setLoading(true);
       const response: AxiosResponse<SubscriptionResponse> = await axios.get(
-        getRequestUrl(request, region, id)
+        getRequestUrlByOptions()
       );
       const res = response.data.data;
 
       const data = res
         .filter((v) => {
-          if (request === 'today' && v.RCRIT_PBLANC_DE !== today) {
+          if (options.condition === 'today' && v.RCRIT_PBLANC_DE !== today) {
             return false;
           }
           return true;
         })
         .map((v) => {
-          const subscriptionState: SubscriptionUsedFront = {
+          const apply: SubscriptionUsedFront = {
             id: v.PBLANC_NO,
             houseName: v.HOUSE_NM,
             recNotice: v.RCRIT_PBLANC_DE,
@@ -82,7 +83,8 @@ const useTodayApply = (request: Request, region?: string, id?: number) => {
             likeNum: -1,
             imgLink: tmpImg,
           };
-          return subscriptionState;
+
+          return apply;
         });
 
       for (let i = 0; i < data.length; i++) {
@@ -99,33 +101,33 @@ const useTodayApply = (request: Request, region?: string, id?: number) => {
   };
 
   useEffect(() => {
-    getSubscriptionsFromServer().then((res) => {
+    get().then((res) => {
       if (res) {
-        switch (request) {
+        switch (options.condition) {
           case 'popular': {
             const popularityList = res
               .sort((a, b) => {
                 return new Date(a.likeNum).getDate() - new Date(b.likeNum).getDate();
               })
               .slice(0, 6);
-            setSubscriptions(popularityList);
+            setApplies(popularityList);
             break;
           }
           case 'new': {
             const latestList = res.sort((a, b) => {
               return new Date(b.recNotice).getDate() - new Date(a.recNotice).getDate();
             });
-            setSubscriptions(latestList);
+            setApplies(latestList);
             break;
           }
         }
 
-        setSubscriptions(res);
+        setApplies(res);
       }
     });
-  }, [request, region]);
+  }, [options.condition, options.region]);
 
-  return { loading, subscriptions };
+  return { loading, applies };
 };
 
-export default useTodayApply;
+export default useApply;

--- a/frontend/src/pages/Detail.tsx
+++ b/frontend/src/pages/Detail.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as BigHeart } from '../assets/icons/bigHeart.svg';
 import { ReactComponent as BigNullHeart } from '../assets/icons/bigNullHeart.svg';
 import { DetailLocation, DetailSchedule, LayoutNavigation, TabBar } from '../components';
 import PALETTE from '../constants/palette';
-import useSubscription from '../hooks/useSubscription';
+import useSubscription from '../hooks/useApply';
 import { DetailState, HelpContents, IDetailOptions } from '../types';
 import axiosInstance from '../utils/axiosInstance';
 

--- a/frontend/src/pages/Detail.tsx
+++ b/frontend/src/pages/Detail.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as BigHeart } from '../assets/icons/bigHeart.svg';
 import { ReactComponent as BigNullHeart } from '../assets/icons/bigNullHeart.svg';
 import { DetailLocation, DetailSchedule, LayoutNavigation, TabBar } from '../components';
 import PALETTE from '../constants/palette';
-import useSubscription from '../hooks/useApply';
+import useApply from '../hooks/useApply';
 import { DetailState, HelpContents, IDetailOptions } from '../types';
 import axiosInstance from '../utils/axiosInstance';
 
@@ -15,7 +15,7 @@ const Detail = () => {
   const state = location.state as DetailState;
   const { id, imgLink } = state;
 
-  const { loading, subscriptions } = useSubscription('id', '', id);
+  const { loading, applies: subscriptions } = useApply({ condition: 'id', id });
   const subscription = subscriptions[0];
 
   const [heartState, setHeartState] = useState(false);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -8,14 +8,13 @@ import Description from '../components/Description';
 import Indexing from '../components/Indexing';
 import ListTitle from '../components/ListTitle';
 import PALETTE from '../constants/palette';
-import useSubscription from '../hooks/useSubscription';
+import useApply from '../hooks/useApply';
 
 const Home = () => {
   const { loading: todaySubscriptionsLoading, subscriptions: todaySubscriptions } =
-    useSubscription('today');
-  const { loading: popularityListLoading, subscriptions: popularityList } =
-    useSubscription('popular');
-  const { loading: latestListLoading, subscriptions: latestList } = useSubscription('new');
+    useApply('today');
+  const { loading: popularityListLoading, subscriptions: popularityList } = useApply('popular');
+  const { loading: latestListLoading, subscriptions: latestList } = useApply('new');
 
   return (
     <LayoutNavigation>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -11,10 +11,13 @@ import PALETTE from '../constants/palette';
 import useApply from '../hooks/useApply';
 
 const Home = () => {
-  const { loading: todaySubscriptionsLoading, subscriptions: todaySubscriptions } =
-    useApply('today');
-  const { loading: popularityListLoading, subscriptions: popularityList } = useApply('popular');
-  const { loading: latestListLoading, subscriptions: latestList } = useApply('new');
+  const { loading: todaySubscriptionsLoading, applies: todaySubscriptions } = useApply({
+    condition: 'today',
+  });
+  const { loading: popularityListLoading, applies: popularityList } = useApply({
+    condition: 'popular',
+  });
+  const { loading: latestListLoading, applies: latestList } = useApply({ condition: 'new' });
 
   return (
     <LayoutNavigation>

--- a/frontend/src/pages/More.tsx
+++ b/frontend/src/pages/More.tsx
@@ -4,13 +4,13 @@ import styled from 'styled-components';
 import { LayoutNavigation } from '../components';
 import Description from '../components/Description';
 import SearchCardList from '../components/SearchCardList';
-import useSubscription from '../hooks/useApply';
+import useApply from '../hooks/useApply';
 import { ListType } from '../types';
 
 const More = () => {
   const { type: typeParam } = useParams();
-  const { loading: popularLoading, subscriptions: popularityList } = useSubscription('popular');
-  const { loading: newLoading, subscriptions: latestList } = useSubscription('new');
+  const { loading: popularLoading, applies: popularityList } = useApply({ condition: 'popular' });
+  const { loading: newLoading, applies: latestList } = useApply({ condition: 'new' });
   const type: ListType = typeParam as ListType;
 
   return (

--- a/frontend/src/pages/More.tsx
+++ b/frontend/src/pages/More.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { LayoutNavigation } from '../components';
 import Description from '../components/Description';
 import SearchCardList from '../components/SearchCardList';
-import useSubscription from '../hooks/useSubscription';
+import useSubscription from '../hooks/useApply';
 import { ListType } from '../types';
 
 const More = () => {

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -5,7 +5,7 @@ import { Input, LayoutNavigation } from '../components';
 import SearchCardList from '../components/SearchCardList';
 import PALETTE from '../constants/palette';
 import useDebounce from '../hooks/useDebounce';
-import useSubscription from '../hooks/useSubscription';
+import useSubscription from '../hooks/useApply';
 import LatestSearchSortButton from '../components/SearchSortButton';
 
 const InputWrapper = styled.div`
@@ -36,7 +36,7 @@ const Search = () => {
     if (e.key === 'Enter') {
       <div>
         <MessageWrapper>총 {subData.length}개의 공고가 있습니다</MessageWrapper>
-        <LatestSearchSortButton/>
+        <LatestSearchSortButton />
         <SearchCardList type="popular" subData={subData} />;
       </div>;
       if (keyword.length === 0) {
@@ -51,7 +51,7 @@ const Search = () => {
         <Input placeholder="지역명을 입력하세요" onChange={onChangeData} onKeyPress={onKeyPress} />
       </InputWrapper>
       <MessageWrapper>총 {subData.length}개의 공고가 있습니다</MessageWrapper>
-      <LatestSearchSortButton/>
+      <LatestSearchSortButton />
       <SearchCardList type="popular" subData={subData} />
     </LayoutNavigation>
   );

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -5,7 +5,7 @@ import { Input, LayoutNavigation } from '../components';
 import SearchCardList from '../components/SearchCardList';
 import PALETTE from '../constants/palette';
 import useDebounce from '../hooks/useDebounce';
-import useSubscription from '../hooks/useApply';
+import useApply from '../hooks/useApply';
 import LatestSearchSortButton from '../components/SearchSortButton';
 
 const InputWrapper = styled.div`
@@ -26,7 +26,7 @@ const MessageWrapper = styled.div`
 const Search = () => {
   const [keyword, setKeyword] = useState<string>('');
   const searchkeyword = useDebounce(keyword, 150);
-  const { subscriptions: subData } = useSubscription('region', searchkeyword);
+  const { applies: subData } = useApply({ condition: 'region', region: searchkeyword });
 
   const onChangeData = (e: React.FormEvent<HTMLInputElement>) => {
     setKeyword(e.currentTarget.value);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/call-apply-api -> dev

### 변경 사항

- heroku에서 공공 API에 다이렉트로 요청합니다.
  - 기존에 백엔드를 거쳐 공공 API에 요청했던 이유는 `vite`에서 환경변수 접근하는 법을 몰라 시크릿키를 설정할 수 없었습니다. 이것을 해결하였습니다. `.env`에 `VITE_APP_API_KEY = 블라블라`를 적어주시면 됩니다. [관련 문서](https://vitejs-kr.github.io/guide/env-and-mode.html#env-files)
- 청약을 `subscription`에서 `apply`로 조금씩 변경 중입니다. 

### 테스트 결과

- 로딩 속도가 크게 개선되지 않았습니다. 좋아요 수를 청약 하나와 연결하면서 생긴 문제였습니다. 적용하는 부분 차후 개선하겠습니다.
- 하나의 훅 안에서 하고 있는 일이 많아 분리 작업을 할 예정입니다.

